### PR TITLE
Change module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Move `@ADR` annotation to `io.github.adr.linked` package to strengthen that it is a link.
+- Changed module name to `io.github.adr` (because offer both `.linked` and `.embedded` packages).
 
 ### Fixed
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ test {
 
 jar {
   manifest {
-    attributes('Automatic-Module-Name': 'io.github.adr.embedded')
+    attributes('Automatic-Module-Name': 'io.github.adr')
   }
 }
 


### PR DESCRIPTION
This is not quite consistent to our gradle module name and project name, but I think, it's better to advertise `io.github.adr` directly. (Maintaining two projects for .embedded and .linked is too much effort)